### PR TITLE
Added an in-place mergesort + documentation; overhauled sort tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ NetLinks can be used to access different DataTypes, like Linked list, Doubly Lin
 and may more. You can even visualize them. It also can be used to sort and search items in these data types.
 
 I should also mention that much of the Basic data class structure is take from the
-University of Toronto's CSC111 course. 
+University of Toronto's CSC111 course.
 
-I and other collaborators are students at 
+I and other collaborators are students at
 University of Toronto, and currently taking CSC111.
 
 Some code is also taken from other sources like Stackoverflow and Geeksforgeeks. All the
@@ -23,12 +23,12 @@ References are mentioned at the bottom of the file.
 - [Merge Sort](#MergeSort)
 
 ## Contribute to NetLinks
-We are very glad 😃 that you want to contribute to our project. We welcome you to our communtiy. Please 
-check the [CONTRIBUTING.md](https://github.com/eeshannarula29/NetLinks/blob/main/CONTRIBUTING.md) file 
-for further information on how you can contribute. 
+We are very glad 😃 that you want to contribute to our project. We welcome you to our communtiy. Please
+check the [CONTRIBUTING.md](https://github.com/eeshannarula29/NetLinks/blob/main/CONTRIBUTING.md) file
+for further information on how you can contribute.
 
 ## Learn Github
-Thses are some resourses you can use to learn the basics of Github. You can always come to the [Discussion board](https://github.com/eeshannarula29/NetLinks/discussions) to discuss the concepts you lernt or have problems with. 
+Thses are some resourses you can use to learn the basics of Github. You can always come to the [Discussion board](https://github.com/eeshannarula29/NetLinks/discussions) to discuss the concepts you lernt or have problems with.
 - [Intro to Git and Github by Daniel Shiffman](https://youtube.com/playlist?list=PLRqwX-V7Uu6ZF9C0YMKuns9sLDzK6zoiV)
 - [Guide to Contributing](https://akrabat.com/the-beginners-guide-to-contributing-to-a-github-project/)
 
@@ -39,8 +39,8 @@ You can clarify all of your queries about github nand collborating on the [Discu
 
 ### Initialize a BST
 
-BST can be initialized in two ways, first by a list, which makes a balanced binary search tree or 
-by constructing a tree from scratch. 
+BST can be initialized in two ways, first by a list, which makes a balanced binary search tree or
+by constructing a tree from scratch.
 
 #### From list
 ```python
@@ -51,9 +51,9 @@ bst = BinarySearchTree.create_tree([1, 2, 4, 10, 20, 30, 3])
 print(bst)
 
 # Output:
-#   _4___   
-#  /     \  
-#  2    20_ 
+#   _4___
+#  /     \
+#  2    20_
 # / \  /   \
 # 1 3 10  30
 ```
@@ -65,11 +65,11 @@ from NetLinks.BinaryTree import BinarySearchTree
 bst = BinarySearchTree(7)
 
 left = BinarySearchTree(3)
-left.set_left_to(BinarySearchTree(2)) 
+left.set_left_to(BinarySearchTree(2))
 left.set_right_to(BinarySearchTree(5))
 
 right = BinarySearchTree(11)
-right.set_left_to(BinarySearchTree(9)) 
+right.set_left_to(BinarySearchTree(9))
 right.set_right_to(BinarySearchTree(13))
 
 bst.set_left_to(left)
@@ -78,16 +78,16 @@ bst.set_right_to(right)
 print(bst)
 
 # Output:
-#   _7__   
-#  /    \  
-#  3   11_ 
+#   _7__
+#  /    \
+#  3   11_
 # / \ /   \
 # 2 5 9  13
 ```
 
 ### Printing BST
 
-#### Branched Form 
+#### Branched Form
 ```python
 from NetLinks.BinaryTree import BinarySearchTree
 
@@ -96,20 +96,20 @@ bst = BinarySearchTree.create_tree([1, 2, 4, 10, 20, 30, 3])
 bst.display()
 
 # Output:
-#   _4___   
-#  /     \  
-#  2    20_ 
+#   _4___
+#  /     \
+#  2    20_
 # / \  /   \
 # 1 3 10  30
 
-# or instead 
+# or instead
 
 print(bst)
 
 # Output:
-#   _4___   
-#  /     \  
-#  2    20_ 
+#   _4___
+#  /     \
+#  2    20_
 # / \  /   \
 # 1 3 10  30
 ```
@@ -131,7 +131,7 @@ bst.display(indented = True)
  #     |->10
  #     |->30
 ```
-### Properties 
+### Properties
 ```python
 from NetLinks.BinaryTree import BinarySearchTree
 
@@ -140,11 +140,11 @@ bst = BinarySearchTree.create_tree([1, 2, 4, 10, 20])
 print(bst)
 
 # Output:
-#   4___ 
+#   4___
 #  /    \
 #  2   20
-# /   /  
-# 1  10  
+# /   /
+# 1  10
 
 print(bst.root) # root value
 # Output:
@@ -153,21 +153,21 @@ print(bst.root) # root value
 print(bst.left) # copy of left child
 # Output:
 #   2
-#  / 
+#  /
 # 1
 
 print(bst.right) # copy of right child
 # Output:
 #   20
-#  / 
+#  /
 # 10
 
 print(bst.height) # height of the tree
-# Output: 
+# Output:
 # 3
 
 print(bst.is_balanced) # Weather tree is balanced
-# Output: 
+# Output:
 # True
 ```
 ### Insert Item in BST
@@ -180,22 +180,22 @@ bst = BinarySearchTree.create_tree([1, 2, 4, 10, 20])
 print(bst)
 
 # Output:
-#   4___ 
+#   4___
 #  /    \
 #  2   20
-# /   /  
-# 1  10 
+# /   /
+# 1  10
 
 bst.insert(3)
 
 print(bst)
 
 # Output:
-#   _4___ 
+#   _4___
 #  /     \
 #  2    20
-# / \  /  
-# 1 3 10  
+# / \  /
+# 1 3 10
 ```
 
 ### Remove Item from BST
@@ -208,21 +208,21 @@ bst = BinarySearchTree.create_tree([1, 2, 3, 4, 5])
 print(bst)
 
 # Output:
-#   3_ 
+#   3_
 #  /  \
 #  2  5
-# /  / 
-# 1  4 
+# /  /
+# 1  4
 
 bst.remove(2)
 
 print(bst)
 
 # Output:
-#  3_ 
+#  3_
 # /  \
 # 1  5
-#   / 
+#   /
 #   4
 ```
 
@@ -265,20 +265,20 @@ bst = BinarySearchTree.create_tree([1, 2, 3, 4, 5])
 print(bst)
 
 # Output:
-#   3_ 
+#   3_
 #  /  \
 #  2  5
-# /  / 
-# 1  4 
+# /  /
+# 1  4
 
 bst.invert()
 
 print(bst)
 
 # Output:
-#  _3  
-# /  \ 
-# 5  2 
+#  _3
+# /  \
+# 5  2
 #  \  \
 #  4  1
 ```
@@ -296,9 +296,9 @@ bst.set_right_to(right)
 print(bst)
 
 # Output:
-# 5  
-#  \ 
-#  6 
+# 5
+#  \
+#  6
 #   \
 #   7
 
@@ -308,7 +308,7 @@ bst.balance()
 print(bst)
 
 # Output:
-#  6 
+#  6
 # / \
 # 5 7
 ```
@@ -324,22 +324,22 @@ bst = BinarySearchTree.create_tree([1, 2, 3, 4, 5])
 print(bst)
 
 # Output:
-#   3_ 
+#   3_
 #  /  \
 #  2  5
-# /  / 
-# 1  4 
+# /  /
+# 1  4
 
 bst.apply(lambda x: x ** 2) # <---- mapping x to x^2
 
 print(bst)
 
 # Output:
-#   9___ 
+#   9___
 #  /    \
 #  4   25
-# /   /  
-# 1  16  
+# /   /
+# 1  16
 ```
 
 #### Creating new Mapped BST
@@ -351,31 +351,31 @@ bst = BinarySearchTree.create_tree([1, 2, 3, 4, 5])
 print(bst)
 
 # Output:
-#   3_ 
+#   3_
 #  /  \
 #  2  5
-# /  / 
-# 1  4 
+# /  /
+# 1  4
 
 mapped = bst.map(lambda x: x ** 2) # <---- mapping x to x^2
 
 print(mapped)
 
 # Output:
-#   9___ 
+#   9___
 #  /    \
 #  4   25
-# /   /  
-# 1  16 
+# /   /
+# 1  16
 
 print(bst)  # bst did not change
 
 # Output:
-#   3_ 
+#   3_
 #  /  \
 #  2  5
-# /  / 
-# 1  4 
+# /  /
+# 1  4
 ```
 
 ### Some other methods
@@ -388,30 +388,30 @@ bst = BinarySearchTree.create_tree([1, 2, 3, 4, 5])
 print(bst)
 
 # Output:
-#   3_ 
+#   3_
 #  /  \
 #  2  5
-# /  / 
-# 1  4 
+# /  /
+# 1  4
 
 # Maximum item in the tree
-print(bst.maximum()) 
+print(bst.maximum())
 # Output:
 # 5
 
 # Minimum item in the tree
-print(bst.mimimum()) 
+print(bst.mimimum())
 # Output:
 # 1
 
 # Copy BST
 print(bst.copy())
 # Output:
-#   3_ 
+#   3_
 #  /  \
 #  2  5
-# /  / 
-# 1  4 
+# /  /
+# 1  4
 
 # abs, floor, and ceil
 abs_bst = bst.abs()  # <- map abs to all element of bst
@@ -422,21 +422,21 @@ ceil_bst = bst.ceil()  # <- map ceil to all element of bst
 ## LinkedLists
 ### Initializing a Linked list
 You can initialize a linked list by simply creating a linked list object
-and optionally pass in a list object witch would contain the initial list 
-items. 
+and optionally pass in a list object witch would contain the initial list
+items.
 
 ```python
 from NetLinks.LinkedList import LinkedList
 
 # create an empty linked list
-lst = LinkedList()  
-# create a linked list with initial values 
+lst = LinkedList()
+# create a linked list with initial values
 lst = LinkedList([1, 10, -3, 5])
 ```
 
 ### Basic Operations
 
-All of the basic operations are taken from the University of Toronto's CSC111 course. 
+All of the basic operations are taken from the University of Toronto's CSC111 course.
 ```python
 from NetLinks.LinkedList import LinkedList
 
@@ -454,7 +454,7 @@ lst.append(2)  # After the call, lst = [1 -> 10 -> 3 -> 5 -> 2]
 # Insert items
 lst.insert(0, 200)  # After the call, lst = [200 -> 1 -> 10 -> 3 -> 5 -> 2]
 
-# Get & Set item by index 
+# Get & Set item by index
 item = lst[1]  # here item = 10
 lst[2] = 100  # set element at index 2 to be 100, so lst = [200 -> 1 -> 100 -> 3 -> 5 -> 2]
 
@@ -467,7 +467,7 @@ popped = lst.pop(0)  # here popped = 200, and lst = [1 -> 100 -> 3 -> 5 -> 2]
 # 2) by item value
 lst.remove(1) # now list lst = [100 -> 3 -> 5 -> 2]
 
-# Checking for Element 
+# Checking for Element
 cond1 = 2 in lst  # here cond1 is True as 2 is in lst
 cond2 = 1 in lst  # here cond2 is False as 1 is not in lst
 
@@ -507,7 +507,7 @@ print(lst)
 # Output:
 # [1 -> 10 -> 3 -> 5]
 
-lst.invert()  # mutate lst 
+lst.invert()  # mutate lst
 
 print(lst)
 # Output:
@@ -521,7 +521,7 @@ from NetLinks.LinkedList import LinkedList
 lst = LinkedList([1, 10, 3, 5])
 
 # Map function f(x) = x^2
-new_lst = lst.map(lambda x: x ** 2) 
+new_lst = lst.map(lambda x: x ** 2)
 
 print(new_lst)
 # Output:
@@ -560,21 +560,21 @@ print(ceil_lst)
 
 ### Initializing a Doubly Linked list
 You can initialize a Doubly linked list by simply creating a Doubly linked list object
-and optionally pass in a list object witch would contain the initial list 
-items. 
+and optionally pass in a list object witch would contain the initial list
+items.
 
 ```python
 from NetLinks.LinkedList import DoublyLinkedList
 
 # create an empty linked list
-lst = DoublyLinkedList()  
-# create a linked list with initial values 
+lst = DoublyLinkedList()
+# create a linked list with initial values
 lst = DoublyLinkedList([1, 10, -3, 5])
 ```
 
 ### Basic Operations
-The idea for all of the basic operations is similar to that of Linked lists, which were taken 
-from the University of Toronto's CSC111 course. 
+The idea for all of the basic operations is similar to that of Linked lists, which were taken
+from the University of Toronto's CSC111 course.
 ```python
 from NetLinks.LinkedList import DoublyLinkedList
 
@@ -592,7 +592,7 @@ lst.append(2)  # After the call, lst = [1 <--> 10 <--> 3 <--> 5 <--> 2]
 # Insert items
 lst.insert(0, 200)  # After the call, lst = [200 <--> 1 <--> 10 <--> 3 <--> 5 <--> 2]
 
-# Get & Set item by index 
+# Get & Set item by index
 item = lst[1]  # here item = 10
 lst[2] = 100  # set element at index 2 to be 100, so lst = [200 <--> 1 <--> 100 <--> 3 <--> 5 <--> 2]
 
@@ -605,7 +605,7 @@ popped = lst.pop(0)  # here popped = 200, and lst = [1 <--> 100 <--> 3 <--> 5 <-
 # 2) by item value
 lst.remove(1) # now list lst = [100 <--> 3 <--> 5 <--> 2]
 
-# Checking for Element 
+# Checking for Element
 cond1 = 2 in lst  # here cond1 is True as 2 is in lst
 cond2 = 1 in lst  # here cond2 is False as 1 is not in lst
 
@@ -645,7 +645,7 @@ print(lst)
 # Output:
 # [1 <--> 10 <--> 3 <--> 5]
 
-lst.invert()  # mutate lst 
+lst.invert()  # mutate lst
 
 print(lst)
 # Output:
@@ -659,7 +659,7 @@ from NetLinks.DoublyLinkedList import DoublyLinkedList
 lst = DoublyLinkedList([1, 10, 3, 5])
 
 # Map function f(x) = x^2
-new_lst = lst.map(lambda x: x ** 2) 
+new_lst = lst.map(lambda x: x ** 2)
 
 print(new_lst)
 # Output:
@@ -695,7 +695,7 @@ print(ceil_lst)
 ```
 
 ## MergeSort
-Use mergesort algorithm to return a sorted list
+Use mergesort algorithm to return a sorted list.
 ```python
 from NetLinks.SortingAlgorithms import mergesort
 
@@ -711,6 +711,106 @@ print(lst)
 print(sorted_lst)
 # Output:
 # [1, 4, 20, 50, 100]
+```
+
+## QuickSort (In Place)
+Use quicksort algorithm to return a sorted list. This is a *mutating* method: it modifies the input instead of returning an output.
+```python
+from NetLinks.SortingAlgorithms import quicksort
+
+# initialize a list
+lst = [1, 100, 50, 20, 4]
+# make a sorted list
+return_value = quicksort(lst)
+
+print(lst)
+# Output:
+# [1, 4, 20, 50, 100]
+
+print(sorted_lst)
+# Output:
+# None
+```
+
+## QuickSort (Non-Mutating)
+Use quicksort algorithm to return a sorted list. This is a *non-mutating* method: the input list will be preserved.
+Note that the runtime of this version is technically inferior to the mutating version of quicksort, above.
+```python
+from NetLinks.SortingAlgorithms import no_mut_quicksort
+
+# initialize a list
+lst = [1, 100, 50, 20, 4]
+# make a sorted list
+sorted_lst = no_mut_quicksort(lst)
+
+print(lst)
+# Output:
+# [1, 100, 50, 20, 4]
+
+print(sorted_lst)
+# Output:
+# [1, 4, 20, 50, 100]
+```
+
+## SelectionSort
+Use the selection sort algorithm to return a sorted list. This is a mutating method that changes the input list.
+```python
+from NetLinks.SortingAlgorithms import selection_sort
+
+# initialize a list
+lst = [1, 100, 50, 20, 4]
+# make a sorted list
+return_value = selection_sort(lst)
+
+print(lst)
+# Output:
+# [1, 4, 20, 50, 100]
+
+print(sorted_lst)
+# Output:
+# None
+```
+
+## InsertionSort
+Use the insertion sort algorithm to return a sorted list. Like selection sort, this is a mutating algorithm that modifies it's input
+```python
+from NetLinks.SortingAlgorithms import insertion_sort
+
+# initialize a list
+lst = [1, 100, 50, 20, 4]
+# make a sorted list
+return_value = insertion_sort(lst)
+
+print(lst)
+# Output:
+# [1, 4, 20, 50, 100]
+
+print(sorted_lst)
+# Output:
+# None
+```
+
+## Sorting Algorithms: The Key Parameter
+Each sorting algorithm accepts an optional `key` parameter: pass in a function to adjust the weighting scheme (or control the values of) of the elements in the list.
+
+For example, if we wanted to sort the list from largest to smallest (rather than smallest to largest, as is default), we can:
+```python
+# Define a function that reverses the weighting of integers
+def invert(x: int) -> int:
+    return -x
+
+# initialize a list
+lst = [1, 100, 50, 20, 4]
+# Sort the list, passing in the function as a key
+return_value = insertion_sort(lst, key=invert)
+
+print(lst)
+# Output:
+# [100, 50, 20, 4, 1]
+
+print(sorted_lst)
+# Output:
+# None
 ```
 
 ## References

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ References are mentioned at the bottom of the file.
 
 ## Current Sorting Algorithms
 
-- [Merge Sort](#MergeSort)
+- [Merge Sort (Non-Mutating)](#MergeSort)
+- [Merge Sort (In Place)](#MergeSort-InPlace)
 - [Quick Sort (In Place)](#QuickSort-InPlace)
 - [Quick Sort (Non-Mutating)](#QuickSort-NonMutating)
 - [Selection Sort](#SelectionSort)
@@ -717,6 +718,26 @@ print(sorted_lst)
 # [1, 4, 20, 50, 100]
 ```
 
+## MergeSort-InPlace
+Use an inplace mergesort algorithm to return a sorted list.
+This version is inferior (in terms of running time) to the non-mutating implementation of mergesort.
+```python
+from NetLinks.SortingAlgorithms import mergesort
+
+# initialize a list
+lst = [1, 100, 50, 20, 4]
+# make a sorted list
+return_value = in_place_mergesort(lst)
+
+print(lst)
+# Output:
+# [1, 4, 20, 50, 100]
+
+print(return_value)
+# Output:
+# None
+```
+
 ## QuickSort-InPlace
 Use quicksort algorithm to return a sorted list. This is a *mutating* method: it modifies the input instead of returning an output.
 ```python
@@ -731,7 +752,7 @@ print(lst)
 # Output:
 # [1, 4, 20, 50, 100]
 
-print(sorted_lst)
+print(return_value)
 # Output:
 # None
 ```
@@ -770,7 +791,7 @@ print(lst)
 # Output:
 # [1, 4, 20, 50, 100]
 
-print(sorted_lst)
+print(return_value)
 # Output:
 # None
 ```
@@ -789,7 +810,7 @@ print(lst)
 # Output:
 # [1, 4, 20, 50, 100]
 
-print(sorted_lst)
+print(return_value)
 # Output:
 # None
 ```

--- a/SortingAlgorithms.py
+++ b/SortingAlgorithms.py
@@ -123,7 +123,7 @@ def _in_place_partition(lst: list, b: int, e: int, key: Callable[[Any], Any]) ->
 ########################################
 # Quick sort (Out of Place)
 ########################################
-def out_place_quicksort(lst: list, key: Callable[[Any], Any] = (lambda x: x)) -> list:
+def no_mut_quicksort(lst: list, key: Callable[[Any], Any] = (lambda x: x)) -> list:
     """Return a sorted list with the elements of lst using the quicksort
     algorithm without in-place optimizations: each recursive call creates a
     new list to be sorted.
@@ -132,12 +132,12 @@ def out_place_quicksort(lst: list, key: Callable[[Any], Any] = (lambda x: x)) ->
         return lst
     else:
         pivot = lst[0]
-        left, right = _out_place_partition(lst[1:], pivot, key)  # We remove the pivot
+        left, right = _no_mut_partition(lst[1:], pivot, key)  # We remove the pivot
 
-        return out_place_quicksort(left, key) + [lst[0]] + out_place_quicksort(right, key)
+        return no_mut_quicksort(left, key) + [lst[0]] + no_mut_quicksort(right, key)
 
 
-def _out_place_partition(lst: list, pivot: Any, key: Callable[[Any], Any]) -> tuple[list, list]:
+def _no_mut_partition(lst: list, pivot: Any, key: Callable[[Any], Any]) -> tuple[list, list]:
     """Partition the list lst relative to the given pivot.
 
     The first index of the tuple is a list of all items smaller than the pivot,

--- a/SortingAlgorithms.py
+++ b/SortingAlgorithms.py
@@ -16,7 +16,55 @@ from typing import Any, Callable
 
 
 ########################################
-# Merge sort
+# Merge sort (In-place)
+########################################
+def in_place_mergesort(lst: list, key: Callable[[Any], Any] = (lambda x: x)) -> None:
+    """
+    Return a sorted list of the items in lst
+    using the merge sort algorithm.
+
+    This algorithm is heavily based off 'Approach 2' by Krikti,
+    https://www.geeksforgeeks.org/in-place-merge-sort/
+    """
+    _in_place_mergesort(lst, 0, len(lst), key)
+
+
+def _in_place_mergesort(lst: list, b: int, e: int, key: Callable[[Any], Any]) -> None:
+    if e - b < 2:  # When there is only one element left in the list
+        return
+    else:
+        m = ((e - b) // 2) + b # Split the list in half
+
+        # Sort each half individual
+        _in_place_mergesort(lst, b, m, key)
+        _in_place_mergesort(lst, m, e, key)
+
+        # Merge and return the sorted half
+        return _in_place_merge(lst, b, m, e, key)
+
+
+def _in_place_merge(lst: list, b: int, m: int, e: int, key: Callable[[Any], Any]) -> None:
+    """Return a single sorted list from two merged input lists."""
+
+    # The initial gap between swappable elements
+    gap = ((e - b + 1) + 1) // 2
+
+    while gap > 0:
+        for i in range(b, e - gap):
+            j = i + gap
+            if key(lst[j]) < key(lst[i]):
+                lst[j], lst[i] = lst[i], lst[j]
+
+        if gap <= 1:
+            gap = 0
+        else:
+            # The +1 forces the cieling of (gap / 2)
+            gap = (gap + 1) // 2
+
+
+
+########################################
+# Merge sort (Non-mutating)
 ########################################
 def mergesort(lst: list, key: Callable[[Any], Any] = (lambda x: x)) -> list:
     """

--- a/tests/test_SortingAlgorithms.py
+++ b/tests/test_SortingAlgorithms.py
@@ -5,6 +5,8 @@ current working directory to PYTHONPATH, in order to 'see'
 the functions it is testing
 """
 
+from typing import Optional, Callable
+
 # Add the root directory to PYTHONPATH
 import sys
 sys.path.append('.')
@@ -13,232 +15,128 @@ from SortingAlgorithms import *
 
 
 ########################################
-# Quick sort (In Place)
+# Base tests for non-mutating sorts
 ########################################
-class TestMergeSort:
+class BaseNoMutatingSort:
+    """The base class for a suit of tests that work with in place sorting algorithms.
+
+    Inherit from this class and assign an algorithm to be used in the tests.
+    """
+    algorithm: Callable[[], None] = staticmethod(None)
+
     def test_unsortedlist(self) -> None:
-        """Test mergesort on an unsorted list"""
+        """Test algorithm on an unsorted list"""
         test_list = [9, 7, 5, 2, 4, 5, 3, 3, 2, 1, 10, 200]
 
-        actual = mergesort(test_list)
+        actual = self.algorithm(test_list)
         expected = sorted(test_list)
 
         assert actual == expected
-
 
     def test_sortedlist(self) -> None:
-        """Test mergesort on an unsorted list"""
+        """Test algorithm on a sorted list"""
         test_list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
-        actual = mergesort(test_list)
+        actual = self.algorithm(test_list)
         expected = sorted(test_list)
 
         assert actual == expected
-
 
     def test_reversedlist(self) -> None:
-        """Test mergesort on an unsorted list"""
+        """Test algorithm on a reversed list"""
         test_list = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
-        actual = mergesort(test_list)
+        actual = self.algorithm(test_list)
         expected = sorted(test_list)
 
         assert actual == expected
 
-
     def test_key_reverse(self) -> None:
-        """Test mergesort on an unsorted list"""
+        """Test algorithm on a list, sort with a reversing key."""
         test_list = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
-        actual = mergesort(test_list, (lambda x: -x))
+        actual = self.algorithm(test_list, (lambda x: -x))
         expected = sorted(test_list, key=(lambda x: -x))
 
         assert actual == expected
 
 
 ########################################
-# Quick sort (In Place)
+# Base tests for mutating sorts
 ########################################
-class TestInPlaceQuickSort:
+class BaseInPlaceSort:
+    """The base class for a suit of tests that work with in place sorting algorithms.
+
+    Inherit from this class and assign an algorithm to be used in the tests.
+    """
+    algorithm: Callable[[], None] = staticmethod(None)
+
     def test_unsortedlist(self) -> None:
-        """Test mergesort on an unsorted list"""
+        """Test algorithm on an unsorted list"""
         test_list = [9, 7, 5, 2, 4, 5, 3, 3, 2, 1, 10, 200]
 
         expected = sorted(test_list.copy())
-        quicksort(test_list)
+        self.algorithm(test_list)
         actual = test_list.copy()
 
         assert actual == expected
 
-
     def test_sortedlist(self) -> None:
-        """Test mergesort on an unsorted list"""
+        """Test algorithm on an sorted list"""
         test_list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
         expected = sorted(test_list.copy())
-        quicksort(test_list)
+        self.algorithm(test_list)
         actual = test_list.copy()
 
         assert actual == expected
 
-
     def test_reversedlist(self) -> None:
-        """Test mergesort on an unsorted list"""
+        """Test algorithm on a reversed list"""
         test_list = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
         expected = sorted(test_list.copy())
-        quicksort(test_list)
+        self.algorithm(test_list)
         actual = test_list.copy()
 
         assert actual == expected
 
-
     def test_key_reverse(self) -> None:
-        """Test mergesort on an unsorted list"""
+        """Test algorithm on a list, sort with a reversing key."""
         test_list = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
-        quicksort(test_list, (lambda x: -x))
+        self.algorithm(test_list, (lambda x: -x))
         actual = test_list.copy()
         expected = sorted(test_list.copy(), key=(lambda x: -x))
 
         assert actual == expected
 
 
-########################################
-# Quick sort (Out of Place)
-########################################
-class TestNoMutQuickSort:
-    def test_unsortedlist(self) -> None:
-        """Test mergesort on an unsorted list"""
-        test_list = [9, 7, 5, 2, 4, 5, 3, 3, 2, 1, 10, 200]
-
-        actual = no_mut_quicksort(test_list)
-        expected = sorted(test_list)
-
-        assert actual == expected
+class TestNoMutatingMergesort(BaseNoMutatingSort):
+    """Test the non-mutating mergesort algorithm"""
+    algorithm: Optional[tuple[Callable[[list], None]]] = staticmethod(mergesort)
 
 
-    def test_sortedlist(self) -> None:
-        """Test mergesort on an unsorted list"""
-        test_list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-        actual = no_mut_quicksort(test_list)
-        expected = sorted(test_list)
-
-        assert actual == expected
+# class TestInPlaceMergesort(BaseNoMutatingSort):
+#     """Test the non-mutating mergesort algorithm"""
+#     algorithm: Optional[tuple[Callable[[list], None]]] = staticmethod(in_place_mergesort)
 
 
-    def test_reversedlist(self) -> None:
-        """Test mergesort on an unsorted list"""
-        test_list = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
-
-        actual = no_mut_quicksort(test_list)
-        expected = sorted(test_list)
-
-        assert actual == expected
+class TestInPlaceQuicksort(BaseInPlaceSort):
+    """Test the mutating quicksort algorithm"""
+    algorithm: Optional[tuple[Callable[[list], None]]] = staticmethod(quicksort)
 
 
-    def test_key_reverse(self) -> None:
-        """Test mergesort on an unsorted list"""
-        test_list = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
-
-        actual = no_mut_quicksort(test_list, (lambda x: -x))
-        expected = sorted(test_list, key=(lambda x: -x))
-
-        assert actual == expected
+class TestNoMutatingQuicksort(BaseNoMutatingSort):
+    """Test the non-mutating quicksort algorithm"""
+    algorithm: Optional[tuple[Callable[[list], None]]] = staticmethod(no_mut_quicksort)
 
 
-########################################
-# Selection Sort
-########################################
-class TestSelectionSort:
-    def test_unsortedlist(self) -> None:
-        """Test mergesort on an unsorted list"""
-        test_list = [9, 7, 5, 2, 4, 5, 3, 3, 2, 1, 10, 200]
-
-        expected = sorted(test_list.copy())
-        selection_sort(test_list)
-        actual = test_list.copy()
-
-        assert actual == expected
+class TestInPlaceInsertionSort(BaseInPlaceSort):
+    """Test the mutating insertionsort algorithm"""
+    algorithm: Optional[tuple[Callable[[list], None]]] = staticmethod(insertion_sort)
 
 
-    def test_sortedlist(self) -> None:
-        """Test mergesort on an unsorted list"""
-        test_list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-        expected = sorted(test_list.copy())
-        selection_sort(test_list)
-        actual = test_list.copy()
-
-        assert actual == expected
-
-
-    def test_reversedlist(self) -> None:
-        """Test mergesort on an unsorted list"""
-        test_list = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
-
-        expected = sorted(test_list.copy())
-        selection_sort(test_list)
-        actual = test_list.copy()
-
-        assert actual == expected
-
-
-    def test_key_reverse(self) -> None:
-        """Test mergesort on an unsorted list"""
-        test_list = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
-
-        selection_sort(test_list, (lambda x: -x))
-        actual = test_list.copy()
-        expected = sorted(test_list.copy(), key=(lambda x: -x))
-
-        assert actual == expected
-
-
-########################################
-# Insertion Sort
-########################################
-class TestInsertionSort:
-    def test_unsortedlist(self) -> None:
-        """Test mergesort on an unsorted list"""
-        test_list = [9, 7, 5, 2, 4, 5, 3, 3, 2, 1, 10, 200]
-
-        expected = sorted(test_list.copy())
-        insertion_sort(test_list)
-        actual = test_list.copy()
-
-        assert actual == expected
-
-
-    def test_sortedlist(self) -> None:
-        """Test mergesort on an unsorted list"""
-        test_list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-        expected = sorted(test_list.copy())
-        insertion_sort(test_list)
-        actual = test_list.copy()
-
-        assert actual == expected
-
-
-    def test_reversedlist(self) -> None:
-        """Test mergesort on an unsorted list"""
-        test_list = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
-
-        expected = sorted(test_list.copy())
-        insertion_sort(test_list)
-        actual = test_list.copy()
-
-        assert actual == expected
-
-
-    def test_key_reverse(self) -> None:
-        """Test mergesort on an unsorted list"""
-        test_list = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
-
-        insertion_sort(test_list, (lambda x: -x))
-        actual = test_list.copy()
-        expected = sorted(test_list.copy(), key=(lambda x: -x))
-
-        assert actual == expected
+class TestInPlaceSelectionSort(BaseInPlaceSort):
+    """Test the mutating selection sort algorithm"""
+    algorithm: Optional[tuple[Callable[[list], None]]] = staticmethod(selection_sort)

--- a/tests/test_SortingAlgorithms.py
+++ b/tests/test_SortingAlgorithms.py
@@ -107,12 +107,12 @@ class TestInPlaceQuickSort:
 ########################################
 # Quick sort (Out of Place)
 ########################################
-class TestOutPlaceQuickSort:
+class TestNoMutQuickSort:
     def test_unsortedlist(self) -> None:
         """Test mergesort on an unsorted list"""
         test_list = [9, 7, 5, 2, 4, 5, 3, 3, 2, 1, 10, 200]
 
-        actual = out_place_quicksort(test_list)
+        actual = no_mut_quicksort(test_list)
         expected = sorted(test_list)
 
         assert actual == expected
@@ -122,7 +122,7 @@ class TestOutPlaceQuickSort:
         """Test mergesort on an unsorted list"""
         test_list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
-        actual = out_place_quicksort(test_list)
+        actual = no_mut_quicksort(test_list)
         expected = sorted(test_list)
 
         assert actual == expected
@@ -132,7 +132,7 @@ class TestOutPlaceQuickSort:
         """Test mergesort on an unsorted list"""
         test_list = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
-        actual = out_place_quicksort(test_list)
+        actual = no_mut_quicksort(test_list)
         expected = sorted(test_list)
 
         assert actual == expected
@@ -142,7 +142,7 @@ class TestOutPlaceQuickSort:
         """Test mergesort on an unsorted list"""
         test_list = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
-        actual = out_place_quicksort(test_list, (lambda x: -x))
+        actual = no_mut_quicksort(test_list, (lambda x: -x))
         expected = sorted(test_list, key=(lambda x: -x))
 
         assert actual == expected

--- a/tests/test_SortingAlgorithms.py
+++ b/tests/test_SortingAlgorithms.py
@@ -117,9 +117,9 @@ class TestNoMutatingMergesort(BaseNoMutatingSort):
     algorithm: Optional[tuple[Callable[[list], None]]] = staticmethod(mergesort)
 
 
-# class TestInPlaceMergesort(BaseNoMutatingSort):
-#     """Test the non-mutating mergesort algorithm"""
-#     algorithm: Optional[tuple[Callable[[list], None]]] = staticmethod(in_place_mergesort)
+class TestInPlaceMergesort(BaseInPlaceSort):
+    """Test the non-mutating mergesort algorithm"""
+    algorithm: Optional[tuple[Callable[[list], None]]] = staticmethod(in_place_mergesort)
 
 
 class TestInPlaceQuicksort(BaseInPlaceSort):


### PR DESCRIPTION
Addressing #6 
- Added the fasted in-place mergesort algorithm I could find; sourced from https://www.geeksforgeeks.org/in-place-merge-sort/, and credit was acknowledged in the docstring.
- Tests for sorting algorithms now rely on base classes, one for in-place algorithms and one for mutating algorithms. This makes writing new tests for all cases easier (less copy + pasting)
- Updated documentation for the new mergesort algorithm to the best of my ability