### PR TITLE
Resolved naming confusion between mutating and non-mutating sorts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,12 +702,12 @@ print(ceil_lst)
 ## MergeSort
 Use mergesort algorithm to return a sorted list.
 ```python
-from NetLinks.SortingAlgorithms import mergesort
+from NetLinks.SortingAlgorithms import no_mut_mergesort
 
 # initialize a list
 lst = [1, 100, 50, 20, 4]
 # make a sorted list
-sorted_lst = mergesort(lst)
+sorted_lst = no_mut_mergesort(lst)
 
 print(lst)
 # Output:
@@ -727,7 +727,7 @@ from NetLinks.SortingAlgorithms import mergesort
 # initialize a list
 lst = [1, 100, 50, 20, 4]
 # make a sorted list
-return_value = in_place_mergesort(lst)
+return_value = mergesort(lst)
 
 print(lst)
 # Output:

--- a/SortingAlgorithms.py
+++ b/SortingAlgorithms.py
@@ -9,6 +9,7 @@ Many of these sort are inspired by the implementation of the CSC111
 University of Toronto Course
 
 Implementation Notes:
+    - Non-mutating algorithms are explicitely prefixed with no_mut_
     - Every top level sorting algorithm (the main function of that algorithm)
         has a default value for key, (lambda x: x) which does not modify it's input
 """
@@ -18,7 +19,7 @@ from typing import Any, Callable
 ########################################
 # Merge sort (In-place)
 ########################################
-def in_place_mergesort(lst: list, key: Callable[[Any], Any] = (lambda x: x)) -> None:
+def mergesort(lst: list, key: Callable[[Any], Any] = (lambda x: x)) -> None:
     """
     Return a sorted list of the items in lst
     using the merge sort algorithm.
@@ -62,11 +63,10 @@ def _in_place_merge(lst: list, b: int, e: int, key: Callable[[Any], Any]) -> Non
             gap = (gap + 1) // 2
 
 
-
 ########################################
 # Merge sort (Non-mutating)
 ########################################
-def mergesort(lst: list, key: Callable[[Any], Any] = (lambda x: x)) -> list:
+def no_mut_mergesort(lst: list, key: Callable[[Any], Any] = (lambda x: x)) -> list:
     """
     Return a sorted list of the items in lst
     using the merge sort algorithm.
@@ -77,14 +77,14 @@ def mergesort(lst: list, key: Callable[[Any], Any] = (lambda x: x)) -> list:
         m = len(lst) // 2  # Split the list in half
 
         # Sort each half individual
-        left = mergesort(lst[:m], key)
-        right = mergesort(lst[m:], key)
+        left = no_mut_mergesort(lst[:m], key)
+        right = no_mut_mergesort(lst[m:], key)
 
         # Merge and return the sorted half
-        return _mergesort_merge(left, right, key)
+        return _no_mut_mergesort_merge(left, right, key)
 
 
-def _mergesort_merge(left: list, right: list, key: Callable[[Any], Any]) -> list:
+def _no_mut_mergesort_merge(left: list, right: list, key: Callable[[Any], Any]) -> list:
     """Return a single sorted list from two merged input lists."""
 
     # Keep track of the current item being inspected in each list
@@ -169,7 +169,7 @@ def _in_place_partition(lst: list, b: int, e: int, key: Callable[[Any], Any]) ->
 
 
 ########################################
-# Quick sort (Out of Place)
+# Quick sort (Non-mutating)
 ########################################
 def no_mut_quicksort(lst: list, key: Callable[[Any], Any] = (lambda x: x)) -> list:
     """Return a sorted list with the elements of lst using the quicksort

--- a/tests/test_DoublyLinkedList.py
+++ b/tests/test_DoublyLinkedList.py
@@ -1,5 +1,9 @@
 """The file contains unit tests for  Doubly linked list class"""
 
+# Add the root directory to PYTHONPATH
+import sys
+sys.path.append('.')
+
 from DoublyLinkedList import DoublyLinkedList
 
 

--- a/tests/test_LinkedList.py
+++ b/tests/test_LinkedList.py
@@ -1,5 +1,9 @@
 """The file contains unit tests for linked list class"""
 
+# Add the root directory to PYTHONPATH
+import sys
+sys.path.append('.')
+
 from LinkedList import LinkedList
 
 

--- a/tests/test_SortingAlgorithms.py
+++ b/tests/test_SortingAlgorithms.py
@@ -112,14 +112,14 @@ class BaseInPlaceSort:
         assert actual == expected
 
 
-class TestNoMutatingMergesort(BaseNoMutatingSort):
+class TestNoMutatingMergesort(BaseInPlaceSort):
     """Test the non-mutating mergesort algorithm"""
     algorithm: Optional[tuple[Callable[[list], None]]] = staticmethod(mergesort)
 
 
-class TestInPlaceMergesort(BaseInPlaceSort):
+class TestInPlaceMergesort(BaseNoMutatingSort):
     """Test the non-mutating mergesort algorithm"""
-    algorithm: Optional[tuple[Callable[[list], None]]] = staticmethod(in_place_mergesort)
+    algorithm: Optional[tuple[Callable[[list], None]]] = staticmethod(no_mut_mergesort)
 
 
 class TestInPlaceQuicksort(BaseInPlaceSort):


### PR DESCRIPTION
Fixes #6 

Non-mutating versions of sorting algorithms are now explicitly marked as `no_mut_`